### PR TITLE
update_features: Fix update flag if hashes match

### DIFF
--- a/www/util.py
+++ b/www/util.py
@@ -41,7 +41,6 @@ def update_features(project, features, audit):
             feat = ref2feat[ref]
             if feat.feature_md5 != md5_hex:
                 update = True
-            update = False
         else:
             feat = Feature(project=project, ref=ref)
             feat.validates_count = 0

--- a/www/util.py
+++ b/www/util.py
@@ -41,7 +41,7 @@ def update_features(project, features, audit):
             feat = ref2feat[ref]
             if feat.feature_md5 != md5_hex:
                 update = True
-            update = True
+            update = False
         else:
             feat = Feature(project=project, ref=ref)
             feat.validates_count = 0


### PR DESCRIPTION
@Zverik @hixi thanks for the great tool!

I am pretty sure this is a bug. Since I'm using the tool for not so long, I am happy about a second pair of eyes/opinion on this. Maybe my usage is wrong, in uploading a Changes-JSON without a audit file, but my intention is to override only the changed features.

#### User-wise

The commit fixes the following case of updating features: You are uploading a set of features (Changes-JSON), where a ref exists, with a corresponding Feature object in the database
  * which already has been validated (and therefore Task objects exist)
  * which has not `feat.audit` data (and not data is in the Audit-File as well)
  * which has the same object data as in the input file (md5-hash match)


So at the moment all Feature related Task objects are deleted and the validates_count of the Feature is reset, despite the object contents are the same.

#### Technically

The change is pretty obvious. 
If the computed content hash matches, update is set to True, despite that no update is needed. So I fix this, in setting this to `False` instead. It now prevents the reset of  `validates_count` of database-features (that are the same in the set of upload-features) in the following line:

https://github.com/mapsme/cf_audit/blob/1089ad5b6ee74ee2bf7953a972062068f3f3f8ab/www/util.py#L65

Alternatively you could remove the whole code line, since it's value is already initialized as `False`.